### PR TITLE
Wrap leaderboard tabs on narrow screens

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -171,7 +171,11 @@
   .lb-panel.active { display: block; }
   .lb-panel h2 { display: none; }
   .lb-panel .sub { margin: 10px 0 6px; }
-  @media (max-width: 720px) { .grid2 { grid-template-columns: minmax(0, 1fr); } }
+  @media (max-width: 720px) {
+    .grid2 { grid-template-columns: minmax(0, 1fr); }
+    .lb-tabs { flex-wrap: wrap; }
+    .lb-tabs button { flex: 1 1 auto; white-space: nowrap; }
+  }
   .section-title {
     font-family: var(--font-display); font-size: 30px; font-weight: 400;
     line-height: 0.9; letter-spacing: 0.010em;


### PR DESCRIPTION
## Problem

The 7-day leaderboards tab bar forces all six tabs to equal widths (`flex: 1 1 0; min-width: 0`). On phone widths, labels such as "AgenticRare" overflow their button and overlap the neighbor tabs.

## Fix

At widths of 720px or less, the tab bars (`.lb-tabs`) wrap and each button takes the width of its label (`flex: 1 1 auto; white-space: nowrap`). This also covers the other tab bars on the page (slice trends, independence views). Desktop layout does not change.

## Verification

Rendered the page with playwright at a 375px viewport. The tabs wrap to a second row with no overlap, and the active-tab indicator follows a tab on the second row correctly (the `move()` handler already uses `offsetTop`, and the `ResizeObserver` re-fires on the height change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)