### PR TITLE
Run the parallel engine at its quality tier (advanced)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Every engine issues one request at a time, so latency samples are comparable
 across engines. Per-engine tuning uses env vars: `TAVILY_DEPTH`; the engine
 entry fixes Keenable's, Exa's, and Parallel's modes (`keenable` = pro,
 `keenable-realtime` = realtime, `exa` = auto, `exa-instant` = instant,
-`parallel` = basic, `parallel-turbo` = turbo). The mean skips queries whose
+`parallel` = advanced, `parallel-turbo` = turbo). The mean skips queries whose
 search or judging failed
 (via `num_scored`; the report lists `search_errors` / `judge_errors`) and
 does not score them as zero.

--- a/src/needle/shared/search/factory.py
+++ b/src/needle/shared/search/factory.py
@@ -100,7 +100,7 @@ ENGINES: dict[str, EngineSpec] = {
     ),
     "brave": EngineSpec(key_env="BRAVE_API_KEY", key_required=True, build=_build_brave),
     "parallel": EngineSpec(
-        key_env="PARALLEL_API_KEY", key_required=True, build=_build_parallel("basic")
+        key_env="PARALLEL_API_KEY", key_required=True, build=_build_parallel("advanced")
     ),
     "parallel-turbo": EngineSpec(
         key_env="PARALLEL_API_KEY", key_required=True, build=_build_parallel("turbo")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -608,7 +608,7 @@ def test_factory_builds_engine_variants(monkeypatch):
     assert clients["exa"].search_type == "auto"
     assert clients["exa-instant"].search_type == "instant"
     assert isinstance(clients["parallel-turbo"], ParallelClient)
-    assert clients["parallel"].mode == "basic"
+    assert clients["parallel"].mode == "advanced"
     assert clients["parallel-turbo"].mode == "turbo"
 
 


### PR DESCRIPTION
## Problem

The engine registry pins each vendor to a quality tier and, where one exists, a separate
fast tier: `keenable` = pro with `keenable-realtime` alongside it, `exa` = auto with
`exa-instant` alongside it. Parallel is pinned differently — `parallel` = **basic**, with
`parallel-turbo` alongside it. Basic is not Parallel's quality tier, so the `parallel` row
measures a mid tier against other vendors' top tiers.

## Solution

Point the `parallel` entry at `mode: "advanced"`. `parallel-turbo` is unchanged and remains
the fast-tier entry.

I re-ran all five suites with all four Parallel modes (turbo, fast, basic, advanced) in a
single pool per suite, on the exact query sets from your published runs — scholar and legal
from the gold committed on `gh-pages`, finance / news / `agentic_rare` reconstructed from the
run artifacts on the HF dataset so the sampled subsets match.

| suite | metric | turbo | fast | basic | advanced |
|---|---|---|---|---|---|
| news | nDCG@5 | 0.5719 | 0.4636 | 0.5175 | **0.5870** |
| agentic_rare | nDCG@5 | 0.3939 | 0.3318 | 0.3954 | **0.5813** |
| scholar | recall@10 | 0.1603 | 0.4049 | 0.4647 | **0.4918** |
| legal | recall@5 | 0.5625 | 0.6354 | 0.6667 | **0.6875** |
| finance | recall@5 | 0.8333 | 0.8250 | **0.9000** | 0.8833 |


## Testing

`uv run pytest tests/test_search.py` — 64 passed. Updated the mode assertion in
`test_factory_builds_engine_variants`; `ParallelClient`'s constructor default is untouched, so
the direct-construction test at `test_parallel_joins_excerpts_and_builds_body` is unaffected.
