### PR TITLE
Brace NEEDLE and AI in the citation title

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ uv run pytest   # deterministic, no network
 ```bibtex
 @misc{needle2026,
   author = {Styskin, Andrey and Petri, Matthias and Gusev, Ilya},
-  title  = {NEEDLE: A Live Open-Source Search Benchmark for AI Agents},
+  title  = {{NEEDLE}: A Live Open-Source Search Benchmark for {AI} Agents},
   year   = {2026},
   url    = {https://keenableai.github.io/needle/},
   note   = {Contact: andrey@keenable.ai, matthias@keenable.ai, ilya.gusev@keenable.ai}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -895,7 +895,7 @@
     <div class="sub">if you use NEEDLE in your work, please cite</div>
     <pre style="margin:8px 0 0; overflow-x:auto; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--text-secondary)">@misc{needle2026,
   author = {Styskin, Andrey and Petri, Matthias and Gusev, Ilya},
-  title  = {NEEDLE: A Live Open-Source Search Benchmark for AI Agents},
+  title  = {{NEEDLE}: A Live Open-Source Search Benchmark for {AI} Agents},
   year   = {2026},
   url    = {https://keenableai.github.io/needle/},
   note   = {Contact: andrey@keenable.ai, matthias@keenable.ai, ilya.gusev@keenable.ai}


### PR DESCRIPTION
BibTeX styles such as plain downcase titles, so the entry rendered as "Needle: A live open-source search benchmark for ai agents". Braces around {NEEDLE} and {AI} protect the case; verified with pdflatex + bibtex (plain style). Applied to both the README and the dashboard citation card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)