### PR TITLE
Make the brand header sticky

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -66,9 +66,14 @@
     counter-reset: sec;
   }
   a { color: var(--link); }
-  .wrap { max-width: calc(var(--measure) + 40px); margin: 0 auto; padding: 28px 20px 56px; }
-  .brand { display: inline-block; margin: 4px 0 34px; }
-  .brand svg { display: block; height: 22px; width: auto; }
+  .wrap { max-width: calc(var(--measure) + 40px); margin: 0 auto; padding: 63px 20px 56px; }
+  .brand {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 60;
+    display: block; margin: 0; padding: 12px 20px;
+    background: var(--page); border-bottom: 1px solid var(--grid);
+    pointer-events: none;
+  }
+  .brand svg { display: block; height: 22px; width: auto; pointer-events: auto; }
   header h1 {
     font-family: var(--font-display); font-size: 38px; font-weight: 400;
     line-height: 0.92; letter-spacing: 0.010em; margin: 0 0 14px; text-wrap: balance;
@@ -98,7 +103,7 @@
   .fm .cadence { font-weight: 300; color: var(--text-muted); }
   header { margin-bottom: 20px; position: relative; }
   header a { color: inherit; }
-  .header-actions { position: absolute; top: 0; right: 0; display: flex; gap: 6px; }
+  .header-actions { position: fixed; top: 8px; right: 20px; z-index: 61; display: flex; gap: 6px; }
   .header-actions button, .header-actions a {
     display: flex; align-items: center; justify-content: center;
     height: 30px; padding: 0 10px;
@@ -119,7 +124,7 @@
   }
   .chart-tools button svg { display: block; }
   .chart-tools button:hover { color: var(--text-primary); border-color: var(--baseline); }
-  .card, .lb-panel { scroll-margin-top: 16px; }
+  .card, .lb-panel { scroll-margin-top: 63px; }
 
   td .key {
     display: inline-block; width: 14px; height: 3px; border-radius: 2px;
@@ -180,7 +185,7 @@
     font-family: var(--font-display); font-size: 30px; font-weight: 400;
     line-height: 0.9; letter-spacing: 0.010em;
     color: var(--text-primary); margin: 64px 0 10px; padding-top: 18px;
-    border-top: 1px solid var(--grid); scroll-margin-top: 16px;
+    border-top: 1px solid var(--grid); scroll-margin-top: 63px;
   }
   .section-title::before {
     counter-increment: sec; content: counter(sec, decimal-leading-zero);
@@ -194,7 +199,7 @@
   #toc { display: none; }
   @media (min-width: 1440px) {
     #toc {
-      display: block; position: fixed; top: 28px; width: 150px;
+      display: block; position: fixed; top: 75px; width: 150px;
       left: calc((100vw - 1080px) / 2 - 172px);
       font-size: 13px; line-height: 1.5;
     }
@@ -386,6 +391,8 @@
 
   @media print {
     .header-actions, .chart-tools, #toc, .runbar, #run-detail, #history-details, .lb-tabs { display: none; }
+    .brand { position: static; padding: 0; margin: 4px 0 34px; border-bottom: none; }
+    .wrap { padding-top: 28px; }
     #card-runs .sub a::after { content: " (" attr(href) ")"; }
     .lb-panel { display: block; }
     .lb-panel h2 { display: block; }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -66,14 +66,15 @@
     counter-reset: sec;
   }
   a { color: var(--link); }
-  .wrap { max-width: calc(var(--measure) + 40px); margin: 0 auto; padding: 63px 20px 56px; }
-  .brand {
-    position: fixed; top: 0; left: 0; right: 0; z-index: 60;
-    display: block; margin: 0; padding: 12px 20px;
-    background: var(--page); border-bottom: 1px solid var(--grid);
-    pointer-events: none;
+  .wrap { max-width: calc(var(--measure) + 40px); margin: 0 auto; padding: 28px 20px 56px; }
+  .topbar {
+    position: sticky; top: -1px; z-index: 60;
+    display: flex; flex-direction: row-reverse; justify-content: space-between; align-items: center;
+    background: var(--page); padding: 12px 0; margin-bottom: 22px;
   }
-  .brand svg { display: block; height: 22px; width: auto; pointer-events: auto; }
+  .topbar.stuck { box-shadow: 0 1px 0 var(--grid); }
+  .brand { display: block; }
+  .brand svg { display: block; height: 22px; width: auto; }
   header h1 {
     font-family: var(--font-display); font-size: 38px; font-weight: 400;
     line-height: 0.92; letter-spacing: 0.010em; margin: 0 0 14px; text-wrap: balance;
@@ -103,7 +104,7 @@
   .fm .cadence { font-weight: 300; color: var(--text-muted); }
   header { margin-bottom: 20px; position: relative; }
   header a { color: inherit; }
-  .header-actions { position: fixed; top: 8px; right: 20px; z-index: 61; display: flex; gap: 6px; }
+  .header-actions { display: flex; gap: 6px; }
   .header-actions button, .header-actions a {
     display: flex; align-items: center; justify-content: center;
     height: 30px; padding: 0 10px;
@@ -124,7 +125,7 @@
   }
   .chart-tools button svg { display: block; }
   .chart-tools button:hover { color: var(--text-primary); border-color: var(--baseline); }
-  .card, .lb-panel { scroll-margin-top: 63px; }
+  .card, .lb-panel { scroll-margin-top: 54px; }
 
   td .key {
     display: inline-block; width: 14px; height: 3px; border-radius: 2px;
@@ -185,7 +186,7 @@
     font-family: var(--font-display); font-size: 30px; font-weight: 400;
     line-height: 0.9; letter-spacing: 0.010em;
     color: var(--text-primary); margin: 64px 0 10px; padding-top: 18px;
-    border-top: 1px solid var(--grid); scroll-margin-top: 63px;
+    border-top: 1px solid var(--grid); scroll-margin-top: 54px;
   }
   .section-title::before {
     counter-increment: sec; content: counter(sec, decimal-leading-zero);
@@ -199,7 +200,7 @@
   #toc { display: none; }
   @media (min-width: 1440px) {
     #toc {
-      display: block; position: fixed; top: 75px; width: 150px;
+      display: block; position: fixed; top: 28px; width: 150px;
       left: calc((100vw - 1080px) / 2 - 172px);
       font-size: 13px; line-height: 1.5;
     }
@@ -391,8 +392,7 @@
 
   @media print {
     .header-actions, .chart-tools, #toc, .runbar, #run-detail, #history-details, .lb-tabs { display: none; }
-    .brand { position: static; padding: 0; margin: 4px 0 34px; border-bottom: none; }
-    .wrap { padding-top: 28px; }
+    .topbar { position: static; }
     #card-runs .sub a::after { content: " (" attr(href) ")"; }
     .lb-panel { display: block; }
     .lb-panel h2 { display: block; }
@@ -419,13 +419,15 @@
   </ul>
 </nav>
 <div class="wrap">
-  <header id="top">
+  <div class="topbar">
     <div class="header-actions">
       <a href="https://github.com/keenableai/needle" title="Source on GitHub" aria-label="Source on GitHub"><svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></a>
       <button id="export-md" title="Open the current tables as Markdown">MD</button>
       <button id="export-pdf" title="Print / save as PDF">PDF</button>
     </div>
     <a class="brand" href="https://keenable.ai" aria-label="Keenable"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 737.122 134" width="737.122" height="134" role="img" aria-label="Keenable"><g fill="#2A2A2A"><path transform="translate(0,0)" d="M 0 128.576 L 0 0 L 20.043 0 L 20.043 128.576 L 0 128.576 Z M 19.854 63.153 L 76.011 0 L 99.646 0 L 37.249 69.204 L 38.195 55.968 L 101.348 128.576 L 75.633 128.576 L 19.854 63.153 Z"></path><path transform="translate(288.14,31.387)" d="M 84.803 38.006 L 84.803 97.188 L 65.895 97.188 L 65.895 42.543 C 65.895 38.258 64.824 34.35 62.681 30.82 C 60.601 27.228 57.796 24.392 54.267 22.312 C 50.737 20.169 46.798 19.097 42.449 19.097 C 38.1 19.097 34.129 20.169 30.537 22.312 C 27.007 24.392 24.171 27.228 22.028 30.82 C 19.948 34.35 18.908 38.258 18.908 42.543 L 18.908 97.188 L 0 97.188 L 0 2.647 L 18.908 2.647 L 18.908 13.047 C 22.186 9.013 26.251 5.83 31.104 3.498 C 35.957 1.166 41.22 0 46.892 0 C 53.888 0 60.254 1.702 65.99 5.105 C 71.725 8.509 76.295 13.078 79.698 18.814 C 83.102 24.549 84.803 30.946 84.803 38.006 Z"></path><path transform="translate(384.394,31.387)" d="M 79.698 2.647 L 98.606 2.647 L 98.606 97.188 L 79.698 97.188 L 78.847 83.007 C 76.074 87.986 72.261 92.02 67.408 95.108 C 62.618 98.134 56.945 99.646 50.39 99.646 C 43.394 99.646 36.84 98.354 30.726 95.77 C 24.675 93.123 19.318 89.499 14.654 84.898 C 10.053 80.234 6.46 74.845 3.876 68.731 C 1.292 62.618 0 56.094 0 49.161 C 0 42.354 1.261 35.989 3.782 30.064 C 6.303 24.139 9.801 18.94 14.276 14.465 C 18.751 9.927 23.95 6.397 29.875 3.876 C 35.8 1.292 42.134 0 48.878 0 C 55.811 0 61.924 1.607 67.219 4.822 C 72.576 7.973 76.988 12.07 80.454 17.112 L 79.698 2.647 Z M 49.918 81.4 C 55.59 81.4 60.538 79.982 64.761 77.146 C 69.047 74.309 72.355 70.528 74.687 65.801 C 77.019 61.011 78.185 55.716 78.185 49.918 C 78.185 43.993 76.988 38.667 74.593 33.94 C 72.261 29.15 68.983 25.369 64.761 22.595 C 60.538 19.759 55.59 18.341 49.918 18.341 C 44.308 18.341 39.172 19.759 34.507 22.595 C 29.843 25.432 26.156 29.245 23.446 34.035 C 20.736 38.825 19.381 44.119 19.381 49.918 C 19.381 55.779 20.768 61.105 23.541 65.895 C 26.377 70.622 30.096 74.404 34.697 77.24 C 39.361 80.013 44.434 81.4 49.918 81.4 Z"></path><path transform="translate(504,0.713)" d="M 48.878 30.675 C 58.08 30.675 66.431 32.912 73.931 37.387 C 81.494 41.862 87.514 47.881 91.988 55.444 C 96.463 62.945 98.701 71.296 98.701 80.498 C 98.701 87.368 97.409 93.828 94.825 99.879 C 92.241 105.866 88.648 111.161 84.047 115.762 C 79.509 120.3 74.215 123.861 68.164 126.445 C 62.177 129.029 55.748 130.321 48.878 130.321 C 42.134 130.321 36.241 128.777 31.199 125.689 C 26.156 122.537 22.06 118.472 18.908 113.493 L 18.908 127.863 L 0 127.863 L 0 0 L 18.908 0 L 18.908 47.503 C 22.06 42.524 26.156 38.49 31.199 35.402 C 36.241 32.25 42.134 30.675 48.878 30.675 Z M 48.689 111.98 C 54.361 111.98 59.498 110.562 64.099 107.726 C 68.763 104.889 72.482 101.076 75.255 96.286 C 78.028 91.496 79.415 86.233 79.415 80.498 C 79.415 74.573 77.996 69.247 75.16 64.52 C 72.387 59.73 68.668 55.949 64.004 53.176 C 59.34 50.339 54.235 48.921 48.689 48.921 C 43.079 48.921 38.132 50.371 33.846 53.27 C 29.623 56.106 26.345 59.919 24.013 64.71 C 21.681 69.437 20.515 74.699 20.515 80.498 C 20.515 86.359 21.681 91.685 24.013 96.475 C 26.408 101.202 29.717 104.984 33.94 107.82 C 38.163 110.593 43.079 111.98 48.689 111.98 Z"></path><path transform="translate(613,0.713)" d="M 0 127.863 L 0 0 L 18.908 0 L 18.908 127.863 L 0 127.863 Z"></path><path transform="translate(642.839,31.71)" d="M 47.271 99.646 C 38.573 99.646 30.631 97.409 23.446 92.934 C 16.324 88.459 10.62 82.471 6.334 74.971 C 2.111 67.408 0 59.057 0 49.918 C 0 42.985 1.229 36.524 3.687 30.537 C 6.145 24.486 9.517 19.192 13.803 14.654 C 18.152 10.053 23.194 6.46 28.93 3.876 C 34.665 1.292 40.779 0 47.271 0 C 54.456 0 61.074 1.481 67.124 4.443 C 73.175 7.406 78.343 11.503 82.629 16.734 C 86.915 21.965 90.066 28.016 92.083 34.886 C 94.1 41.693 94.73 48.909 93.974 56.536 L 20.232 56.536 C 21.051 61.137 22.69 65.265 25.148 68.92 C 27.606 72.513 30.726 75.381 34.507 77.524 C 38.289 79.604 42.543 80.675 47.271 80.738 C 52.25 80.738 56.756 79.478 60.79 76.956 C 64.887 74.435 68.227 71 70.811 66.651 L 90.003 71.095 C 86.221 79.478 80.518 86.348 72.891 91.705 C 65.265 96.999 56.725 99.646 47.271 99.646 Z M 19.57 42.071 L 74.877 42.071 C 74.309 37.407 72.702 33.152 70.055 29.308 C 67.471 25.463 64.193 22.406 60.223 20.137 C 56.252 17.868 51.935 16.734 47.271 16.734 C 42.607 16.734 38.321 17.868 34.413 20.137 C 30.505 22.343 27.259 25.369 24.675 29.213 C 22.091 33.058 20.389 37.344 19.57 42.071 Z"></path></g><g transform="translate(99.081,31.71)"><path fill="#005CFF" d="M 48.524 0 C 55.9 0 62.694 1.521 68.905 4.562 C 75.116 7.602 80.422 11.808 84.821 17.178 C 89.221 22.548 92.456 28.759 94.526 35.812 C 96.597 42.799 97.244 50.208 96.468 58.036 L 58.023 58.063 C 33.115 58.082 25.821 92.045 48.524 102.29 C 39.596 102.29 31.444 99.993 24.068 95.399 C 16.757 90.806 10.902 84.659 6.502 76.96 C 2.167 69.196 0 60.623 0 51.242 C 0 44.125 1.262 37.493 3.785 31.347 C 6.308 25.136 9.77 19.701 14.169 15.043 C 18.633 10.32 23.81 6.632 29.697 3.979 C 35.585 1.327 41.861 0 48.524 0 Z M 52.608 16.733 C 47.944 16.733 43.659 17.869 39.751 20.138 C 35.843 22.344 32.597 25.368 30.013 29.213 C 27.429 33.057 25.728 37.343 24.908 42.07 L 80.215 42.07 C 79.648 37.406 78.04 33.152 75.393 29.308 C 72.809 25.463 69.531 22.407 65.561 20.138 C 61.59 17.869 57.272 16.733 52.608 16.733 Z"></path><path fill="#2A2A2A" transform="translate(51.255,21.698)" d="M 15.499 0 C 15.947 0 16.39 0.019 16.828 0.057 C 19.685 2.096 22.123 4.613 24.138 7.61 C 26.785 11.455 28.392 15.709 28.959 20.373 L 0.783 20.373 C 0.276 18.84 0 17.202 0 15.499 C 0 6.939 6.939 0 15.499 0 Z"></path></g><g transform="translate(180.218,31.71)"><path fill="#005CFF" d="M 48.524 0 C 55.9 0 62.694 1.521 68.905 4.562 C 75.116 7.602 80.422 11.808 84.821 17.178 C 89.221 22.548 92.456 28.759 94.526 35.812 C 96.597 42.799 97.244 50.208 96.468 58.036 L 58.067 58.036 C 33.141 58.036 25.813 92.017 48.524 102.29 C 39.596 102.29 31.444 99.993 24.068 95.399 C 16.757 90.806 10.902 84.659 6.502 76.96 C 2.167 69.196 0 60.623 0 51.242 C 0 44.125 1.262 37.493 3.785 31.347 C 6.308 25.136 9.77 19.701 14.169 15.043 C 18.633 10.32 23.81 6.632 29.697 3.979 C 35.585 1.327 41.861 0 48.524 0 Z M 51.485 16.733 C 46.821 16.733 42.536 17.869 38.628 20.138 C 34.72 22.344 31.475 25.368 28.891 29.213 C 26.307 33.057 24.605 37.343 23.785 42.07 L 79.092 42.07 C 78.525 37.406 76.917 33.152 74.27 29.308 C 71.685 25.463 68.408 22.407 64.438 20.138 C 60.467 17.869 56.149 16.733 51.485 16.733 Z"></path><path fill="#2A2A2A" transform="translate(49.161,21.698)" d="M 15.499 0 C 16.352 0 17.189 0.07 18.005 0.202 C 20.775 2.215 23.143 4.684 25.109 7.61 C 27.757 11.455 29.364 15.709 29.932 20.373 L 0.783 20.373 C 0.276 18.84 0 17.202 0 15.499 C 0 6.939 6.939 0 15.499 0 Z"></path></g></svg></a>
+  </div>
+  <header id="top">
     <h1>NEEDLE: Which search API moves the needle for AI&nbsp;agents?</h1>
     <div class="fm">
       <p class="lastrun"><span id="updated"></span>
@@ -2977,6 +2979,10 @@ document.getElementById("cite-copy").addEventListener("click", async (e) => {
   setTimeout(() => { e.target.textContent = "Copy"; }, 1200);
 });
 window.addEventListener("beforeprint", () => drawAllTrends?.());
+
+const topbar = document.querySelector(".topbar");
+new IntersectionObserver(([e]) => topbar.classList.toggle("stuck", e.intersectionRatio < 1),
+  { threshold: 1 }).observe(topbar);
 
 for (const n of document.querySelectorAll("[data-vert]")) {
   n.textContent = verticalName(n.dataset.vert);


### PR DESCRIPTION
The logo and the GitHub / MD / PDF buttons keep their original place in the content column, but the row is now `position: sticky`, so it stays on screen at any scroll position, on mobile and desktop.

- The brand link and `.header-actions` move into a new `.topbar` flex row, first child of `.wrap`.
- A small IntersectionObserver adds a `.stuck` class when the row is pinned, which draws a hairline shadow under it; at the top of the page the header looks exactly as before.
- Anchor targets get `scroll-margin-top` so jumps land below the bar; print keeps the static header.

Screenshots (playwright, 390px and 1500px, top and scrolled):
- [mobile, top](https://paste.keenable.ai/needle-floating-header-v2-mobile-top)
- [mobile, scrolled](https://paste.keenable.ai/needle-floating-header-v2-mobile-scrolled)
- [desktop, top](https://paste.keenable.ai/needle-floating-header-v2-desktop-top)
- [desktop, scrolled](https://paste.keenable.ai/needle-floating-header-v2-desktop-scrolled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)