### PR TITLE
Add a URL-intersection matrix and reword the suspicious-sharing subtitle

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -697,11 +697,12 @@
   </div>
 
   <div class="card" id="card-independence" data-tools>
-    <h2>Index independence — three views</h2>
-    <div class="sub">suspicious-sharing matrix, borrowing graph, and per-engine
-      result uniqueness</div>
+    <h2>Index independence — four views</h2>
+    <div class="sub">suspicious-sharing matrix, URL-intersection matrix,
+      borrowing graph, and per-engine result uniqueness</div>
     <div class="lb-tabs" role="tablist" aria-label="Index independence views">
       <button role="tab" aria-selected="true" class="active" data-panel="card-lowshared">suspicious sharing</button>
+      <button role="tab" aria-selected="false" data-panel="card-urlshare">URL intersection</button>
       <button role="tab" aria-selected="false" data-panel="card-sharegraph">borrowing graph</button>
       <button role="tab" aria-selected="false" data-panel="card-uniqueness">uniqueness</button>
       <div class="tab-ind" aria-hidden="true"></div>
@@ -711,6 +712,12 @@
       <div class="sub" id="lowshared-sub"></div>
       <div class="overlap-matrix" id="lowshared-table"></div>
       <div class="overlap-pair" id="lowshared-pair" aria-live="polite"></div>
+    </div>
+    <div class="lb-panel" id="card-urlshare" role="tabpanel">
+      <h2>URL intersection</h2>
+      <div class="sub" id="urlshare-sub"></div>
+      <div class="overlap-matrix" id="urlshare-table"></div>
+      <div class="overlap-pair" id="urlshare-pair" aria-live="polite"></div>
     </div>
     <div class="lb-panel" id="card-sharegraph" role="tabpanel">
       <h2>Borrowing graph (all runs)</h2>
@@ -2102,7 +2109,7 @@ const overlapStep = (v) => {
   return i === -1 ? 4 : i;
 };
 
-function overlapMatrix(holder, engines, cellFor) {
+function overlapMatrix(holder, engines, cellFor, pairNote = "of queries share suspiciously") {
   const table = el("table");
   const head = el("tr");
   head.appendChild(el("th", {}, ""));
@@ -2183,7 +2190,7 @@ function overlapMatrix(holder, engines, cellFor) {
         el("b", {}, displayName(engines[ri])),
         document.createTextNode(" × "),
         el("b", {}, displayName(engines[cj])),
-        document.createTextNode(cell ? ` — ${cell.text} of queries share suspiciously` : " — no comparable queries"),
+        document.createTextNode(cell ? ` — ${cell.text} ${pairNote}` : " — no comparable queries"),
       );
     }
   };
@@ -2193,8 +2200,10 @@ function overlapMatrix(holder, engines, cellFor) {
 
 function renderOverlap(rows, uniqAgg) {
   const lowHolder = document.getElementById("lowshared-table");
+  const shareHolder = document.getElementById("urlshare-table");
   const graphHolder = document.getElementById("sharegraph");
   lowHolder.replaceChildren();
+  shareHolder.replaceChildren();
   graphHolder.replaceChildren();
   const pairKey = (a, b) => (a < b ? `${a}|${b}` : `${b}|${a}`);
   const pairs = new Map();
@@ -2204,11 +2213,15 @@ function renderOverlap(rows, uniqAgg) {
     seen.add(r.b);
     const key = pairKey(r.a, r.b);
     let agg = pairs.get(key);
-    if (!agg) pairs.set(key, agg = { low2: 0, lowUrls: 0, nLow: 0 });
+    if (!agg) pairs.set(key, agg = { low2: 0, lowUrls: 0, nLow: 0, shared: 0, union: 0 });
     if (r.num_suspect != null) {
       agg.low2 += r.num_suspect;
       agg.lowUrls += r.low_shared_urls || 0;
       agg.nLow += r.num_queries;
+    }
+    if (r.union_urls != null) {
+      agg.shared += r.shared_urls;
+      agg.union += r.union_urls;
     }
   }
   const engines = ENGINES.filter((e) => seen.has(e));
@@ -2218,11 +2231,12 @@ function renderOverlap(rows, uniqAgg) {
   const emptyMsg = "No overlap data yet.";
   if (engines.length < 2) {
     lowHolder.appendChild(el("div", { class: "empty" }, emptyMsg));
+    shareHolder.appendChild(el("div", { class: "empty" }, emptyMsg));
     graphHolder.appendChild(el("div", { class: "empty" }, emptyMsg));
     return;
   }
   document.getElementById("lowshared-sub").textContent =
-    "share of queries where the pair shares a below-HM URL or 3+ URLs of any rating";
+    "share of queries where the pair shares an irrelevant URL or 3+ URLs of any rating";
   overlapMatrix(lowHolder, engines, (a, b) => {
     const agg = pairs.get(pairKey(a, b));
     if (!agg || !agg.nLow) return null;
@@ -2233,6 +2247,18 @@ function renderOverlap(rows, uniqAgg) {
       title: `${displayName(a)} ∩ ${displayName(b)}: ${agg.low2} of ${agg.nLow} queries share a low-relevance URL or 3+ URLs (${agg.lowUrls} junk URLs total)`,
     };
   });
+  document.getElementById("urlshare-sub").textContent =
+    "pooled Jaccard: shared URLs / union of the pair's URLs over comparable queries, ignoring ratings (runs since 2026-08-27)";
+  overlapMatrix(shareHolder, engines, (a, b) => {
+    const agg = pairs.get(pairKey(a, b));
+    if (!agg || !agg.union) return null;
+    const v = agg.shared / agg.union;
+    return {
+      text: `${Math.round(v * 100)}%`,
+      step: overlapStep(v),
+      title: `${displayName(a)} ∩ ${displayName(b)}: ${agg.shared} shared of ${agg.union} pooled URLs`,
+    };
+  }, "of pooled URLs shared");
   renderSharingGraph(graphHolder, engines, pairs, uniqAgg);
 }
 

--- a/src/needle/shared/overlap.py
+++ b/src/needle/shared/overlap.py
@@ -56,12 +56,16 @@ def overlap_rows(report: dict[str, Any], *, ts: str) -> list[dict[str, Any]]:
         for b in names[i + 1 :]:
             suspect = 0
             low_shared_urls = 0
+            shared_urls = 0
+            union_urls = 0
             n = 0
             for qi, (sa, sb) in enumerate(zip(url_sets[a], url_sets[b], strict=True)):
                 if sa is None or sb is None or not (sa or sb):
                     continue
                 low = (low_sets[a][qi] or set()) & (low_sets[b][qi] or set())
                 low_shared_urls += len(low)
+                shared_urls += len(sa & sb)
+                union_urls += len(sa | sb)
                 suspect += len(low) >= 1 or len(sa & sb) >= 3
                 n += 1
             rows.append(
@@ -71,6 +75,8 @@ def overlap_rows(report: dict[str, Any], *, ts: str) -> list[dict[str, Any]]:
                     "b": b,
                     "num_suspect": suspect,
                     "low_shared_urls": low_shared_urls,
+                    "shared_urls": shared_urls,
+                    "union_urls": union_urls,
                     "num_queries": n,
                 }
             )

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -22,6 +22,8 @@ def test_overlap_rows_pairs():
     assert set(by_pair) == {("e1", "e2"), ("e1", "e3"), ("e2", "e3")}
     r12 = by_pair[("e1", "e2")]
     assert r12["num_queries"] == 2
+    assert r12["shared_urls"] == 1
+    assert r12["union_urls"] == 5
     assert r12["ts"] == "2026-07-02T10:00Z"
 
 


### PR DESCRIPTION
## What

- The suspicious-sharing subtitle now says "an irrelevant URL" instead of "a below-HM URL".
- New "URL intersection" tab in the Index independence card (now "four views"). Each cell shows pooled Jaccard: shared URLs / union of the pair's URLs over all comparable queries, with the same color scale and hover behavior as the suspicious-sharing matrix.
- `overlap_rows` now records `shared_urls` and `union_urls` per pair so the publish pipeline feeds the new chart.

## Data caveat

`overlap.jsonl` is append-only and old rows lack the new fields, so the matrix pools runs from 2026-08-27 on. The dashboard skips rows without `union_urls`, so old data does not break it.

## Verification

- `uv run pytest tests/test_overlap.py` — 15 passed.
- Scratch site with fixtures (legacy rows mixed with new rows), playwright screenshots:
  - URL intersection tab: https://paste.keenable.ai/8djBawmcC5q5a8iuQGMyle
  - Reworded suspicious-sharing tab: https://paste.keenable.ai/FyeRLA8WVJOYc6lihPjSsv

🤖 Generated with [Claude Code](https://claude.com/claude-code)