### PR TITLE
Backfill: treat overlap rows without shared_urls/union_urls as stale

### DIFF
--- a/scripts/backfill_overlap.py
+++ b/scripts/backfill_overlap.py
@@ -38,7 +38,7 @@ def backfill(site: str, hours: int | None = None, dataset: str | None = None) ->
     runs_base = f"{resolve_base(dataset)}/runs"
     overlap = load_jsonl(data / "overlap.jsonl")
     uniqueness = load_jsonl(data / "uniqueness.jsonl")
-    overlap_done = _done(overlap, ("num_suspect", "low_shared_urls"))
+    overlap_done = _done(overlap, ("num_suspect", "low_shared_urls", "shared_urls", "union_urls"))
     uniqueness_done = _done(uniqueness, ("unique_relevant_urls",))
     cutoff = (
         (datetime.now(UTC) - timedelta(hours=hours)).strftime(TS_FMT) if hours is not None else ""


### PR DESCRIPTION
Follow-up to #10, which merged before this commit reached the branch. The hourly workflow backfill (`--hours 24`) and manual full runs now recompute overlap rows published before `shared_urls`/`union_urls` existed.

A full manual backfill of all 1,248 runs is already prepared and waiting to be pushed to `gh-pages`; this change keeps the last-24h window self-healing for runs that land between that push and future deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)