### PR TITLE
Fit the index-independence tables on mobile widths

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -390,6 +390,17 @@
     background: var(--track); vertical-align: middle; margin-right: 8px;
   }
   .bar-table .bar-fill { display: block; height: 100%; border-radius: 0; }
+  @media (max-width: 560px) {
+    .overlap-matrix table { border-spacing: 1px; font-size: 10px; }
+    .overlap-matrix td:first-child { padding: 0 3px 0 1px; }
+    .overlap-matrix td:first-child .ename { display: none; }
+    .overlap-matrix th:last-child, .overlap-matrix td.row-logo { display: none; }
+    .overlap-matrix td.overlap-cell { width: 21px; min-width: 21px; height: 24px; }
+    .bar-table { font-size: 12px; }
+    .bar-table td, .bar-table th { padding: 6px 4px; }
+    .bar-table td:last-child, .bar-table th:last-child { white-space: normal; }
+    .bar-table .bar-track { width: 36px; margin-right: 5px; }
+  }
   #sharegraph svg { max-width: 460px; margin: 0 auto; }
   #sharegraph .sg-edge { stroke: var(--text-muted); }
   #sharegraph .sg-arrow { fill: var(--text-primary); }
@@ -1006,7 +1017,7 @@ function engineKey(engine) {
 
 function engineCell(engine, cls = "") {
   const td = el("td", { class: cls });
-  td.append(engineKey(engine), document.createTextNode(displayName(engine)));
+  td.append(engineKey(engine), el("span", { class: "ename" }, displayName(engine)));
   return td;
 }
 let history = [];


### PR DESCRIPTION
On phones the suspicious-sharing matrix showed only 7 of 11 engine columns (473px table in a ~312px viewport-width container); the URL-intersection matrix and the uniqueness table also overflowed and forced horizontal scrolling.

Below 560px:
- Both overlap matrices switch to logo-only row headers (a `.ename` span in `engineCell`, hidden by a rule scoped to `.overlap-matrix`), drop the redundant trailing logo column, and use 21px cells with 1px spacing. The full 11x11 grid now fits a 360px viewport. Tapping a cell still names both engines in the pair line under the matrix.
- The uniqueness bar table gets a 36px bar, tighter padding, 12px font, and a wrapping URLs column.

Verified with playwright at 360px and 390px viewports: `scrollWidth == clientWidth` for `lowshared-table`, `urlshare-table`, and `uniqueness-table` at both widths; desktop rendering unchanged at 1280px.

- Before (390px): https://paste.keenable.ai/optPdzlrozKY3Xmfal1nBp
- After, matrix (390px): https://paste.keenable.ai/MJR9p2I0AvMhkglYP1ran7
- After, uniqueness (390px): https://paste.keenable.ai/W4oCO5hgZY4oNb1IodvhZx

🤖 Generated with [Claude Code](https://claude.com/claude-code)