### PR TITLE
Keep Exa on highlights when snippets are uncapped

### DIFF
--- a/src/needle/shared/search/exa.py
+++ b/src/needle/shared/search/exa.py
@@ -1,7 +1,10 @@
 from typing import Any
 
-from needle.shared.search.base import HttpSearchClient, SearchResult
+from needle.shared.search.base import HttpSearchClient, SearchResult, clamped_chars
 from needle.shared.search.queryops import parse_ops
+
+MIN_HIGHLIGHT_CHARS = 1
+MAX_HIGHLIGHT_CHARS = 10000
 
 
 class ExaClient(HttpSearchClient):
@@ -14,12 +17,14 @@ class ExaClient(HttpSearchClient):
         api_key: str,
         search_type: str = "auto",
         include_text: bool = True,
+        highlights: bool = True,
         highlight_chars: int = 0,
         timeout_s: float = 30.0,
     ) -> None:
         super().__init__(api_key=api_key, timeout_s=timeout_s)
         self.search_type = search_type
         self.include_text = include_text
+        self.highlights = highlights
         self.highlight_chars = highlight_chars
 
     async def search(
@@ -37,8 +42,15 @@ class ExaClient(HttpSearchClient):
             body["startPublishedDate"] = f"{ops.after.isoformat()}T00:00:00.000Z"
         if ops.before:
             body["endPublishedDate"] = f"{ops.before.isoformat()}T23:59:59.999Z"
-        if self.highlight_chars > 0:
-            body["contents"] = {"highlights": {"maxCharacters": self.highlight_chars}}
+        if self.highlights:
+            body["contents"] = {
+                "highlights": {
+                    "maxCharacters": clamped_chars(
+                        self.highlight_chars, MIN_HIGHLIGHT_CHARS, MAX_HIGHLIGHT_CHARS
+                    )
+                    or MAX_HIGHLIGHT_CHARS
+                }
+            }
         elif self.include_text:
             body["contents"] = {"text": True}
         payload, err = await self._request_json(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -113,17 +113,34 @@ async def test_exa_maps_fields_and_builds_body(monkeypatch):
         "query": "hi",
         "numResults": 5,
         "type": "auto",
-        "contents": {"text": True},
+        "contents": {"highlights": {"maxCharacters": 10000}},
     }
     assert calls["headers"] == {"x-api-key": "x"}
 
 
-async def test_exa_omits_contents_when_text_disabled(monkeypatch):
-    c = ExaClient(api_key="x", include_text=False)
+async def test_exa_omits_contents_when_highlights_and_text_disabled(monkeypatch):
+    c = ExaClient(api_key="x", highlights=False, include_text=False)
     fake, calls = _canned({"results": []})
     monkeypatch.setattr(c, "_request_json", fake)
     await c.search("hi")
     assert "contents" not in calls["json"]
+
+
+@pytest.mark.parametrize("chars,expected", [(500, 500), (20000, 10000), (0, 10000)])
+async def test_exa_clamps_highlight_chars(monkeypatch, chars, expected):
+    c = ExaClient(api_key="x", highlight_chars=chars)
+    fake, calls = _canned({"results": []})
+    monkeypatch.setattr(c, "_request_json", fake)
+    await c.search("hi")
+    assert calls["json"]["contents"] == {"highlights": {"maxCharacters": expected}}
+
+
+async def test_exa_uses_text_when_highlights_disabled(monkeypatch):
+    c = ExaClient(api_key="x", highlights=False, include_text=True)
+    fake, calls = _canned({"results": []})
+    monkeypatch.setattr(c, "_request_json", fake)
+    await c.search("hi")
+    assert calls["json"]["contents"] == {"text": True}
 
 
 async def test_exa_highlights_mode(monkeypatch):
@@ -134,6 +151,19 @@ async def test_exa_highlights_mode(monkeypatch):
     results, err = await c.search("hi")
     assert calls["json"]["contents"] == {"highlights": {"maxCharacters": 500}}
     assert results[0].snippet == "one\ntwo"
+
+
+async def test_exa_translates_query_operators(monkeypatch):
+    c = ExaClient(api_key="x")
+    fake, calls = _canned({"results": []})
+    monkeypatch.setattr(c, "_request_json", fake)
+
+    await c.search(OPS_QUERY)
+
+    assert calls["json"]["query"] == "acme filing"
+    assert calls["json"]["includeDomains"] == ["sec.gov"]
+    assert calls["json"]["startPublishedDate"] == "2026-06-01T00:00:00.000Z"
+    assert calls["json"]["endPublishedDate"] == "2026-06-30T23:59:59.999Z"
 
 
 async def test_searchapi_maps_kg_answer_box_and_organic(monkeypatch):


### PR DESCRIPTION
`--snippet-chars 0` means no cap. Other adapters handle this by removing the cap and keeping their native snippets, but Exa was falling back to full text. So uncapping snippets was changing what Exa returned, not just how much. `create_clients` defaults to `snippet_chars=0`, so library callers hit this too.

Uncapped now uses highlights at the API max of 10k chars, and anything above 10k gets clamped. Raw full text is still available with `highlights=False`. CI uses the 2000 char default, so published numbers don't change.

This matters for quality too. Raw text is generally worse than highlights!
