### PR TITLE
Raise scholar bench step timeout to 180 minutes

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: scholar (daily schedule, dispatch opt-in, or gold bootstrap)
         id: scholar
         continue-on-error: true
-        timeout-minutes: 120
+        timeout-minutes: 180
         env:
           RUN_SCHOLAR: ${{ github.event.schedule == '17 12 * * *' || inputs.scholar == true }}
         run: |


### PR DESCRIPTION
The scholar step timed out at 120 minutes in run [33189977912](https://github.com/keenableai/needle/actions/runs/33189977912). Yesterday's scholar run took 2h00m and finished seconds under the cap, so the bench has drifted over its limit rather than hung.

Root cause of the slowness: `search_all` in `src/needle/shared/search/base.py` awaits every search sequentially — 336 scholar queries x 15 engines = 5,040 serial requests. This PR only raises the step cap to 180 minutes as a stopgap; parallelizing `search_all` per engine is the real fix and can follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPrfnoLufsvfq7gmoMTK2d