### PR TITLE
Add TinyFish as a search engine

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -49,9 +49,10 @@ env:
   CERAMIC_API_KEY: ${{ secrets.CERAMIC_API_KEY }}
   YOU_API_KEY: ${{ secrets.YOU_API_KEY }}
   FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+  TINYFISH_API_KEY: ${{ secrets.TINYFISH_API_KEY }}
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   HF_DATASET: keenable-ai/needle-results
-  ENGINES: keenable-realtime,keenable,exa-instant,exa,google,bing,brave,brave-llmcontext,parallel-turbo,parallel,tavily,perplexity,octen,ceramic,you,firecrawl
+  ENGINES: keenable-realtime,keenable,exa-instant,exa,google,bing,brave,brave-llmcontext,parallel-turbo,parallel,tavily,perplexity,octen,ceramic,you,firecrawl,tinyfish
 
 jobs:
   bench:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The CLI loads `.env` from the working directory (copy
 | Variable | Purpose |
 | --- | --- |
 | `OPENROUTER_API_KEY` | all LLM work — query projection (news, finance `filingdoc`, scholar, legal `code`) and judging |
-| `EXA_API_KEY`, `SERPER_API_KEY` (`google`), `SEARCHAPI_API_KEY` (`bing`), `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `PERPLEXITY_API_KEY`, `OCTEN_API_KEY`, `CERAMIC_API_KEY`, `YOU_API_KEY`, `FIRECRAWL_API_KEY` | one per engine, required when that engine is in `--engines` |
+| `EXA_API_KEY`, `SERPER_API_KEY` (`google`), `SEARCHAPI_API_KEY` (`bing`), `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `PERPLEXITY_API_KEY`, `OCTEN_API_KEY`, `CERAMIC_API_KEY`, `YOU_API_KEY`, `FIRECRAWL_API_KEY`, `TINYFISH_API_KEY` | one per engine, required when that engine is in `--engines` |
 | `KEENABLE_API_KEY` | optional — without it the CLI uses the keyless, rate-limited endpoint |
 | `NEEDLE_LLM_MODEL`, `NEEDLE_JUDGE_MODEL` | both default to `openai/gpt-5.6-terra`; `--llm-model` / `--judge-model` override |
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -56,6 +56,7 @@
     --series-11: #6F8433;
     --series-12: #814800;
     --series-13: #B3322B;
+    --series-14: #8A7500;
   }
   * { box-sizing: border-box; }
   body {
@@ -967,10 +968,11 @@ registerEngines(["keenable-realtime", "google", "bing", "brave", "brave-llmconte
   "exa", "exa-instant", "parallel", "parallel-turbo", "perplexity", "tavily", "you", "firecrawl",
   "tinyfish"]);
 
+const SERIES_COUNT = 14;
 function colorOf(engine) {
   if (engine === ULTIMATE_ENGINE) return "var(--text-muted)";
   const slot = ENGINE_SLOT.get(engine);
-  return slot == null || slot >= 13 ? "var(--text-muted)" : `var(--series-${slot + 1})`;
+  return slot == null || slot >= SERIES_COUNT ? "var(--text-muted)" : `var(--series-${slot + 1})`;
 }
 const MARKER_SHAPES = ["circle", "square", "diamond", "up", "down"];
 function markerEl(engine, x, y, r) {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -904,6 +904,7 @@
       <tr><td>parallel-turbo</td><td>Parallel POST /v1/search</td><td>same as parallel but mode=turbo</td></tr>
       <tr><td>perplexity</td><td>Perplexity POST /search</td><td>max_results=min(k,20), search_context_size=low; site: → search_domain_filter, after:/before: → search_after_date_filter/search_before_date_filter (MM/DD/YYYY)</td></tr>
       <tr><td>tavily</td><td>Tavily POST /search</td><td>search_depth=basic, max_results=min(k,20); site: → include_domains, after:/before: → start_date/end_date (ISO dates)</td></tr>
+      <tr><td>tinyfish</td><td>TinyFish GET api.search.tinyfish.ai</td><td>query = query text clipped to 2,000 chars; no count parameter — we keep the first k results; site: → include_domains (comma-separated), after:/before: → after_date/before_date (ISO dates)</td></tr>
       <tr><td>you</td><td>You.com POST /v1/search</td><td>count=min(k,100); site: → include_domains, after:/before: → freshness=YYYY-MM-DDtoYYYY-MM-DD; web and news sections merge, deduplicated by URL</td></tr>
       <tr><td>firecrawl</td><td>Firecrawl POST /v2/search</td><td>limit=min(k,100), sources=[web]; site: kept in the query text, after:/before: → tbs=cdr:1,cd_min:M/D/YYYY,cd_max:M/D/YYYY</td></tr>
     </table>
@@ -963,7 +964,8 @@ function registerEngines(names) {
 }
 
 registerEngines(["keenable-realtime", "google", "bing", "brave", "brave-llmcontext",
-  "exa", "exa-instant", "parallel", "parallel-turbo", "perplexity", "tavily", "you", "firecrawl"]);
+  "exa", "exa-instant", "parallel", "parallel-turbo", "perplexity", "tavily", "you", "firecrawl",
+  "tinyfish"]);
 
 function colorOf(engine) {
   if (engine === ULTIMATE_ENGINE) return "var(--text-muted)";
@@ -1863,6 +1865,7 @@ const PRICES = new Map([
   ["you", { usd: 5.00, plan: "Web Search API plan" }],
   ["firecrawl", { usd: 1.20, plan: "Scale — $599/mo / 1M credits, 2 credits per search" }],
   ["octen", { usd: 1.00, plan: "pay-as-you-go" }],
+  ["tinyfish", { usd: 0.00, plan: "free" }],
   ["ceramic", { usd: 0.05, plan: "pay-as-you-go" }],
 ]);
 const fmtUsd = (v) => `$${v.toFixed(2)}`;

--- a/src/needle/shared/search/__init__.py
+++ b/src/needle/shared/search/__init__.py
@@ -20,6 +20,7 @@ from needle.shared.search.perplexity import PerplexityClient
 from needle.shared.search.searchapi import SearchApiClient
 from needle.shared.search.serper import SerperClient
 from needle.shared.search.tavily import TavilyClient
+from needle.shared.search.tinyfish import TinyFishClient
 from needle.shared.search.you import YouClient
 
 __all__ = [
@@ -39,6 +40,7 @@ __all__ = [
     "SearchResult",
     "SerperClient",
     "TavilyClient",
+    "TinyFishClient",
     "YouClient",
     "build_search_clients",
     "capped_snippet",

--- a/src/needle/shared/search/factory.py
+++ b/src/needle/shared/search/factory.py
@@ -14,6 +14,7 @@ from needle.shared.search.perplexity import PerplexityClient
 from needle.shared.search.searchapi import SearchApiClient
 from needle.shared.search.serper import SerperClient
 from needle.shared.search.tavily import TavilyClient
+from needle.shared.search.tinyfish import TinyFishClient
 from needle.shared.search.you import YouClient
 
 
@@ -84,6 +85,10 @@ def _build_tavily(api_key: str | None, snippet_chars: int) -> SearchClient:
     return TavilyClient(api_key=api_key or "", search_depth=os.environ.get("TAVILY_DEPTH", "basic"))
 
 
+def _build_tinyfish(api_key: str | None, snippet_chars: int) -> SearchClient:
+    return TinyFishClient(api_key=api_key or "")
+
+
 def _build_you(api_key: str | None, snippet_chars: int) -> SearchClient:
     return YouClient(api_key=api_key or "")
 
@@ -121,6 +126,7 @@ ENGINES: dict[str, EngineSpec] = {
         key_env="PERPLEXITY_API_KEY", key_required=True, build=_build_perplexity
     ),
     "tavily": EngineSpec(key_env="TAVILY_API_KEY", key_required=True, build=_build_tavily),
+    "tinyfish": EngineSpec(key_env="TINYFISH_API_KEY", key_required=True, build=_build_tinyfish),
     "octen": EngineSpec(key_env="OCTEN_API_KEY", key_required=True, build=_build_octen),
     "ceramic": EngineSpec(key_env="CERAMIC_API_KEY", key_required=True, build=_build_ceramic),
     "you": EngineSpec(key_env="YOU_API_KEY", key_required=True, build=_build_you),

--- a/src/needle/shared/search/octen.py
+++ b/src/needle/shared/search/octen.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from needle.shared.search.base import HttpSearchClient, SearchResult
-from needle.shared.search.queryops import parse_ops
+from needle.shared.search.queryops import clipped_text, parse_ops
 
 MAX_QUERY_CHARS = 500
 
@@ -20,11 +20,8 @@ class OctenClient(HttpSearchClient):
         self, query: str, *, num_results: int = 10
     ) -> tuple[list[SearchResult] | None, dict[str, str] | None]:
         ops = parse_ops(query)
-        text = ops.text
-        if len(text) > MAX_QUERY_CHARS:
-            text = text[:MAX_QUERY_CHARS].rsplit(" ", 1)[0]
         body: dict[str, Any] = {
-            "query": text,
+            "query": clipped_text(ops.text, MAX_QUERY_CHARS),
             "count": num_results,
             "highlight": {"enable": True, "max_tokens": self.highlight_max_tokens},
         }

--- a/src/needle/shared/search/queryops.py
+++ b/src/needle/shared/search/queryops.py
@@ -31,6 +31,10 @@ def freshness_window(ops: QueryOps) -> str | None:
     return f"{lo.isoformat()}to{hi.isoformat()}"
 
 
+def clipped_text(text: str, max_chars: int) -> str:
+    return text[:max_chars].rsplit(" ", 1)[0] if len(text) > max_chars else text
+
+
 def parse_ops(query: str) -> QueryOps:
     text_parts: list[str] = []
     sites: list[str] = []

--- a/src/needle/shared/search/tinyfish.py
+++ b/src/needle/shared/search/tinyfish.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from needle.shared.search.base import HttpSearchClient, SearchResult
-from needle.shared.search.queryops import parse_ops
+from needle.shared.search.queryops import clipped_text, parse_ops
 
 MAX_QUERY_CHARS = 2000
 
@@ -14,10 +14,7 @@ class TinyFishClient(HttpSearchClient):
         self, query: str, *, num_results: int = 10
     ) -> tuple[list[SearchResult] | None, dict[str, str] | None]:
         ops = parse_ops(query)
-        text = ops.text
-        if len(text) > MAX_QUERY_CHARS:
-            text = text[:MAX_QUERY_CHARS].rsplit(" ", 1)[0]
-        params: dict[str, Any] = {"query": text}
+        params: dict[str, Any] = {"query": clipped_text(ops.text, MAX_QUERY_CHARS)}
         if ops.sites:
             params["include_domains"] = ",".join(ops.sites)
         if ops.after:
@@ -32,7 +29,7 @@ class TinyFishClient(HttpSearchClient):
         )
         if err is not None:
             return None, err
-        raw_results = payload.get("results") if isinstance(payload, dict) else None
+        raw_results = payload.get("results", []) if isinstance(payload, dict) else []
         results = [
             SearchResult(
                 url=r["url"],
@@ -40,7 +37,7 @@ class TinyFishClient(HttpSearchClient):
                 snippet=r.get("snippet") or None,
                 published_date=r.get("date") or None,
             )
-            for r in (raw_results if isinstance(raw_results, list) else [])[:num_results]
+            for r in raw_results[:num_results]
             if isinstance(r, dict) and r.get("url")
         ]
         return results, None

--- a/src/needle/shared/search/tinyfish.py
+++ b/src/needle/shared/search/tinyfish.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+from needle.shared.search.base import HttpSearchClient, SearchResult
+from needle.shared.search.queryops import parse_ops
+
+MAX_QUERY_CHARS = 2000
+
+
+class TinyFishClient(HttpSearchClient):
+    engine = "tinyfish"
+    base_url = "https://api.search.tinyfish.ai"
+
+    async def search(
+        self, query: str, *, num_results: int = 10
+    ) -> tuple[list[SearchResult] | None, dict[str, str] | None]:
+        ops = parse_ops(query)
+        text = ops.text
+        if len(text) > MAX_QUERY_CHARS:
+            text = text[:MAX_QUERY_CHARS].rsplit(" ", 1)[0]
+        params: dict[str, Any] = {"query": text}
+        if ops.sites:
+            params["include_domains"] = ",".join(ops.sites)
+        if ops.after:
+            params["after_date"] = ops.after.isoformat()
+        if ops.before:
+            params["before_date"] = ops.before.isoformat()
+        payload, err = await self._request_json(
+            "GET",
+            self.base_url,
+            params=params,
+            headers={"X-API-Key": self.api_key},
+        )
+        if err is not None:
+            return None, err
+        raw_results = payload.get("results") if isinstance(payload, dict) else None
+        results = [
+            SearchResult(
+                url=r["url"],
+                title=r.get("title") or None,
+                snippet=r.get("snippet") or None,
+                published_date=r.get("date") or None,
+            )
+            for r in (raw_results if isinstance(raw_results, list) else [])[:num_results]
+            if isinstance(r, dict) and r.get("url")
+        ]
+        return results, None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -610,26 +610,17 @@ async def test_ceramic_maps_fields_and_builds_body(monkeypatch):
 
 async def test_tinyfish_maps_fields_and_builds_params(monkeypatch):
     payload = {
-        "query": "acme filing",
         "results": [
-            {
-                "position": 1,
-                "url": "https://a",
-                "title": "A",
-                "snippet": "sa",
-                "date": "Jun 9, 2026",
-            },
-            {"position": 2, "url": "https://b", "title": "", "snippet": ""},
-            {"position": 3, "title": "no url"},
-        ],
-        "total_results": 3,
-        "page": 0,
+            {"url": "https://a", "title": "A", "snippet": "sa", "date": "Jun 9, 2026"},
+            {"url": "https://b", "title": "", "snippet": ""},
+            {"title": "no url"},
+        ]
     }
     c = TinyFishClient(api_key="k")
     fake, calls = _canned(payload)
     monkeypatch.setattr(c, "_request_json", fake)
 
-    results, err = await c.search(OPS_QUERY, num_results=5)
+    results, err = await c.search("hi", num_results=5)
     assert err is None
     assert [r.url for r in results] == ["https://a", "https://b"]
     assert results[0].snippet == "sa"
@@ -639,12 +630,7 @@ async def test_tinyfish_maps_fields_and_builds_params(monkeypatch):
     assert results[1].published_date is None
     assert calls["method"] == "GET"
     assert calls["url"] == "https://api.search.tinyfish.ai"
-    assert calls["params"] == {
-        "query": "acme filing",
-        "include_domains": "sec.gov",
-        "after_date": "2026-06-01",
-        "before_date": "2026-06-30",
-    }
+    assert calls["params"] == {"query": "hi"}
     assert calls["headers"] == {"X-API-Key": "k"}
 
 
@@ -1264,6 +1250,17 @@ async def test_brave_freshness_fills_open_ends(monkeypatch):
             {"result": {"results": []}},
             "json",
             {"query": "acme filing"},
+        ),
+        (
+            lambda: TinyFishClient(api_key="k"),
+            {"results": []},
+            "params",
+            {
+                "query": "acme filing",
+                "include_domains": "sec.gov",
+                "after_date": "2026-06-01",
+                "before_date": "2026-06-30",
+            },
         ),
         (
             lambda: YouClient(api_key="k"),

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -18,6 +18,7 @@ from needle.shared.search import (
     SearchResult,
     SerperClient,
     TavilyClient,
+    TinyFishClient,
     YouClient,
     build_search_clients,
     latency_stats,
@@ -607,6 +608,62 @@ async def test_ceramic_maps_fields_and_builds_body(monkeypatch):
     assert calls["headers"] == {"Authorization": "Bearer k"}
 
 
+async def test_tinyfish_maps_fields_and_builds_params(monkeypatch):
+    payload = {
+        "query": "acme filing",
+        "results": [
+            {
+                "position": 1,
+                "url": "https://a",
+                "title": "A",
+                "snippet": "sa",
+                "date": "Jun 9, 2026",
+            },
+            {"position": 2, "url": "https://b", "title": "", "snippet": ""},
+            {"position": 3, "title": "no url"},
+        ],
+        "total_results": 3,
+        "page": 0,
+    }
+    c = TinyFishClient(api_key="k")
+    fake, calls = _canned(payload)
+    monkeypatch.setattr(c, "_request_json", fake)
+
+    results, err = await c.search(OPS_QUERY, num_results=5)
+    assert err is None
+    assert [r.url for r in results] == ["https://a", "https://b"]
+    assert results[0].snippet == "sa"
+    assert results[0].published_date == "Jun 9, 2026"
+    assert results[1].title is None
+    assert results[1].snippet is None
+    assert results[1].published_date is None
+    assert calls["method"] == "GET"
+    assert calls["url"] == "https://api.search.tinyfish.ai"
+    assert calls["params"] == {
+        "query": "acme filing",
+        "include_domains": "sec.gov",
+        "after_date": "2026-06-01",
+        "before_date": "2026-06-30",
+    }
+    assert calls["headers"] == {"X-API-Key": "k"}
+
+
+async def test_tinyfish_clips_query_chars(monkeypatch):
+    c = TinyFishClient(api_key="k")
+    fake, calls = _canned({"results": []})
+    monkeypatch.setattr(c, "_request_json", fake)
+
+    long_query = " ".join(f"word{i}" for i in range(400))
+    await c.search(long_query)
+    sent = calls["params"]["query"]
+    assert len(sent) <= 2000
+    assert long_query.startswith(sent)
+    assert not sent.endswith(" ")
+
+    await c.search("hi")
+    assert calls["params"] == {"query": "hi"}
+
+
 async def test_octen_clips_query_chars(monkeypatch):
     c = OctenClient(api_key="k")
     fake, calls = _canned({"data": {"results": []}})
@@ -771,6 +828,7 @@ def test_factory_builds_new_engines(monkeypatch):
     monkeypatch.setenv("CERAMIC_API_KEY", "ck")
     monkeypatch.setenv("YOU_API_KEY", "yk")
     monkeypatch.setenv("FIRECRAWL_API_KEY", "fk")
+    monkeypatch.setenv("TINYFISH_API_KEY", "tfk")
     clients = build_search_clients(
         [
             "google",
@@ -783,6 +841,7 @@ def test_factory_builds_new_engines(monkeypatch):
             "ceramic",
             "you",
             "firecrawl",
+            "tinyfish",
         ]
     )
     assert isinstance(clients["google"], SerperClient)
@@ -803,6 +862,8 @@ def test_factory_builds_new_engines(monkeypatch):
     assert clients["you"].api_key == "yk"
     assert isinstance(clients["firecrawl"], FirecrawlClient)
     assert clients["firecrawl"].api_key == "fk"
+    assert isinstance(clients["tinyfish"], TinyFishClient)
+    assert clients["tinyfish"].api_key == "tfk"
 
 
 def test_factory_builds_engine_variants(monkeypatch):


### PR DESCRIPTION
Adds the `tinyfish` engine (TinyFish Search, `GET https://api.search.tinyfish.ai`, `X-API-Key` auth).

- New client `src/needle/shared/search/tinyfish.py`: maps `url`/`title`/`snippet`/`date`; `site:` → `include_domains` (comma-separated), `after:`/`before:` → `after_date`/`before_date`; clips query text to the API's 2,000-char limit. No count parameter — we keep the first k results.
- Registered in the factory under `TINYFISH_API_KEY`, added to the bench workflow env + `ENGINES`, README key table, and the dashboard (appendix F row, engine registry, price table — the search endpoint is free).
- Tests: field/param mapping, query clipping, factory build. Live-verified plain, `site:`, and `after:` queries.

Needs the `TINYFISH_API_KEY` repo secret before the next bench run on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)