### PR TITLE
Fix quality-vs-price chart layout for zero-price engines

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -339,8 +339,6 @@
   #card-quality-price { width: fit-content; max-width: 100%; margin-left: auto; margin-right: auto; }
   #quality-price { padding: 4px 0 8px; overflow-x: auto; }
   #quality-price svg { height: auto; }
-  #quality-price .qp-name { fill: var(--text-primary); font-size: 12px; }
-  #quality-price .qp-name.home-name { fill: var(--keenable-blue); }
   #quality-price .qp-tick { fill: var(--text-primary); fill-opacity: 0.32; font-family: var(--font-utility); font-size: 11px; letter-spacing: -0.004em; font-variant-numeric: tabular-nums; }
   #quality-price .qp-axis { fill: var(--text-primary); font-family: var(--font-utility); font-size: 12px; letter-spacing: -0.004em; }
   #quality-price .qp-axis .dim { fill: var(--text-muted); }
@@ -1998,70 +1996,43 @@ function renderQualityPrice(rows) {
   xT.appendChild(el("tspan", {}, "Price, $ per 1k queries"));
   xT.appendChild(el("tspan", { class: "dim" }, " — lowest public tier"));
   svg.appendChild(xT);
-  const items = pts.map((p) => ({ ...p, px: X(p.usd), yPos: Y(p.q), labelY: Y(p.q) }));
-  for (const it of items) {
-    const g = el("g", { class: "qp-mark" });
-    const home = it.e === HOME_ENGINE;
-    g.appendChild(el("circle", { cx: it.px, cy: it.yPos, r: 5,
-      fill: home ? "var(--keenable-blue)" : "var(--text-primary)" }));
-    const logo = ENGINE_LOGOS.get(it.e);
-    it.logo = logo ? el("image", { href: logo, width: 16, height: 16 }) : null;
-    if (it.logo) g.appendChild(it.logo);
-    it.label = el("text", { class: "qp-name" + (home ? " home-name" : "") }, displayName(it.e));
-    g.appendChild(it.label);
-    it.g = g;
-    svg.appendChild(g);
-  }
-  const halo = el("circle", { r: 10, fill: "none", stroke: "var(--keenable-blue)",
-    "stroke-width": 1.5, "stroke-opacity": 0.6, visibility: "hidden" });
-  svg.appendChild(halo);
-  holder.appendChild(svg);
-  for (const it of items) {
-    const tw = it.label.getComputedTextLength();
-    it.off = it.logo ? 31 : 11;
-    it.right = it.px + it.off + tw <= M.left + iw - 6;
-    it.label.setAttribute("text-anchor", it.right ? "start" : "end");
-    it.x0 = it.right ? it.px + 11 : it.px - it.off - tw;
-    it.x1 = it.right ? it.px + it.off + tw : it.px - 11;
-  }
-  const yMin = M.top + 12, yMax = M.top + ih - 16;
+  const items = pts.map((p) => ({ ...p, px: X(p.usd), yPos: Y(p.q) }));
   const order = [...items].sort((a, b) => a.yPos - b.yPos || a.px - b.px);
   const placed = [];
-  const clash = (it, y) => {
-    for (const o of placed) {
-      if (it.x0 < o.x1 && o.x0 < it.x1 && Math.abs(y - o.labelY) < 18) return true;
-    }
-    for (const o of items) {
-      if (o !== it && o.px > it.x0 - 6 && o.px < it.x1 + 6 &&
-          Math.abs(o.px - it.px) > 5 && Math.abs(y - o.yPos) < 14) return true;
-    }
-    return false;
-  };
   for (const it of order) {
-    it.labelY = it.yPos;
-    for (let k = 0; k <= 24; k++) {
-      const cand = it.yPos + (k % 2 ? 1 : -1) * Math.ceil(k / 2) * 6;
-      if (cand < yMin || cand > yMax) continue;
-      if (!clash(it, cand)) {
-        it.labelY = cand;
+    it.cy = it.yPos;
+    for (let k = 0; k <= 20; k++) {
+      const cand = it.yPos + (k % 2 ? 1 : -1) * Math.ceil(k / 2) * 5;
+      if (cand < M.top + 10 || cand > M.top + ih - 10) continue;
+      if (placed.every((o) => Math.abs(o.px - it.px) >= 17 || Math.abs(o.cy - cand) >= 17)) {
+        it.cy = cand;
         break;
       }
     }
-    it.labelY = Math.max(yMin, Math.min(yMax, it.labelY));
     placed.push(it);
   }
   for (const it of items) {
-    if (Math.abs(it.labelY - it.yPos) > 5) {
-      it.g.insertBefore(el("line", { x1: it.px, y1: it.yPos + Math.sign(it.labelY - it.yPos) * 6,
-        x2: it.px, y2: it.labelY, stroke: "var(--baseline)", "stroke-width": 1 }), it.g.firstChild);
+    const g = el("g", { class: "qp-mark" });
+    const home = it.e === HOME_ENGINE;
+    const logo = ENGINE_LOGOS.get(it.e);
+    if (home) {
+      g.appendChild(el("circle", { cx: it.px, cy: it.cy, r: 14,
+        fill: "none", stroke: "var(--keenable-blue)", "stroke-width": 1.5 }));
     }
-    it.label.setAttribute("x", it.px + (it.right ? it.off : -it.off));
-    it.label.setAttribute("y", it.labelY + 4);
-    if (it.logo) {
-      it.logo.setAttribute("x", it.right ? it.px + 11 : it.px - 27);
-      it.logo.setAttribute("y", it.labelY - 8);
+    if (logo) {
+      g.appendChild(el("image", { href: logo, x: it.px - 9, y: it.cy - 9,
+        width: 18, height: 18 }));
+    } else {
+      g.appendChild(el("circle", { cx: it.px, cy: it.cy, r: 5,
+        fill: home ? "var(--keenable-blue)" : "var(--text-primary)" }));
     }
+    it.g = g;
+    svg.appendChild(g);
   }
+  const halo = el("circle", { r: 14, fill: "none", stroke: "var(--keenable-blue)",
+    "stroke-width": 1.5, "stroke-opacity": 0.6, visibility: "hidden" });
+  svg.appendChild(halo);
+  holder.appendChild(svg);
 
   const tip = el("div", { class: "tooltip qp-tip" });
   card.appendChild(tip);
@@ -2077,7 +2048,7 @@ function renderQualityPrice(rows) {
       tipRow("price", `${fmtUsd(it.usd)} / 1k queries`), el("div", { class: "plan" }, it.plan));
     tip.style.display = "block";
     halo.setAttribute("cx", it.px);
-    halo.setAttribute("cy", it.yPos);
+    halo.setAttribute("cy", it.cy);
     halo.setAttribute("visibility", "visible");
     svg.classList.add("qp-hot");
     for (const other of items) other.g.classList.toggle("is-hot", other === it);
@@ -2093,9 +2064,7 @@ function renderQualityPrice(rows) {
     for (const it of items) it.g.classList.remove("is-hot");
   }
   for (const it of items) {
-    it.g.appendChild(el("rect", { class: "qp-hit", x: it.x0, y: it.labelY - 10,
-      width: Math.max(it.x1 - it.x0, 1), height: 20 }));
-    it.g.appendChild(el("circle", { class: "qp-hit", cx: it.px, cy: it.yPos, r: 11 }));
+    it.g.appendChild(el("circle", { class: "qp-hit", cx: it.px, cy: it.cy, r: 12 }));
     it.g.addEventListener("pointerenter", () => showTip(it));
     it.g.addEventListener("pointerleave", hideTip);
   }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1955,7 +1955,7 @@ function renderQualityPrice(rows) {
   const yHi = Math.min(1, Math.ceil((Math.max(...qs) + 0.04) * 20) / 20);
   const yStep = yHi - yLo <= 0.3 ? 0.05 : 0.1;
   const xPad = 30;
-  const X = (v) => M.left + xPad + (v / xTop) * (iw - xPad);
+  const X = (v) => M.left + xPad + Math.sqrt(v / xTop) * (iw - xPad);
   const Y = (v) => M.top + (1 - (v - yLo) / (yHi - yLo)) * ih;
   const svg = el("svg", { viewBox: `0 0 ${W} ${H}`, width: W, height: H, role: "img",
     "aria-label": "Overall quality as share of ultimate vs price per 1,000 queries" });
@@ -1978,7 +1978,13 @@ function renderQualityPrice(rows) {
     svg.appendChild(el("text", { x: M.left + 6, y: Math.min(Y(gv) + 14, M.top + ih - 22),
       class: "qp-tick" }, fmtPct(gv)));
   }
-  for (let v = 0; v <= xTop; v++) {
+  const xTicks = [0];
+  for (let v = 1; v < xTop; v++) {
+    if (X(v) - X(xTicks[xTicks.length - 1]) >= 48) xTicks.push(v);
+  }
+  if (X(xTop) - X(xTicks[xTicks.length - 1]) < 40) xTicks.pop();
+  xTicks.push(xTop);
+  for (const v of xTicks) {
     const edge = v === xTop;
     svg.appendChild(el("text", { x: X(v) + (edge ? -3 : 3), y: M.top + ih - 7,
       "text-anchor": edge ? "end" : "start", class: "qp-tick" }, `$${v}`));
@@ -1992,44 +1998,72 @@ function renderQualityPrice(rows) {
   xT.appendChild(el("tspan", {}, "Price, $ per 1k queries"));
   xT.appendChild(el("tspan", { class: "dim" }, " — lowest public tier"));
   svg.appendChild(xT);
-  const items = pts.map((p) => ({ ...p, px: X(p.usd), yPos: Y(p.q), right: X(p.usd) < M.left + iw - 130 }));
-  const clusters = [];
-  for (const side of [true, false]) {
-    const row = items.filter((it) => it.right === side).sort((a, b) => a.px - b.px);
-    let group = null;
-    for (const it of row) {
-      if (group && it.px - group[group.length - 1].px < 90) group.push(it);
-      else clusters.push(group = [it]);
-    }
-  }
-  for (const group of clusters) stackLabels(group, M.top + 12, M.top + ih - 10, 18);
+  const items = pts.map((p) => ({ ...p, px: X(p.usd), yPos: Y(p.q), labelY: Y(p.q) }));
   for (const it of items) {
     const g = el("g", { class: "qp-mark" });
     const home = it.e === HOME_ENGINE;
-    const s = it.right ? 1 : -1;
-    if (Math.abs(it.labelY - it.yPos) > 4) {
-      g.appendChild(el("line", { x1: it.px, y1: it.yPos + Math.sign(it.labelY - it.yPos) * 6,
-        x2: it.px, y2: it.labelY, stroke: "var(--baseline)", "stroke-width": 1 }));
-    }
     g.appendChild(el("circle", { cx: it.px, cy: it.yPos, r: 5,
       fill: home ? "var(--keenable-blue)" : "var(--text-primary)" }));
     const logo = ENGINE_LOGOS.get(it.e);
-    if (logo) {
-      g.appendChild(el("image", { href: logo, x: it.right ? it.px - 27 : it.px + 11,
-        y: it.labelY - 8, width: 16, height: 16 }));
-    }
-    it.label = el("text", { x: it.px + s * 11, y: it.labelY + 4,
-      "text-anchor": it.right ? "start" : "end",
-      class: "qp-name" + (home ? " home-name" : "") }, displayName(it.e));
+    it.logo = logo ? el("image", { href: logo, width: 16, height: 16 }) : null;
+    if (it.logo) g.appendChild(it.logo);
+    it.label = el("text", { class: "qp-name" + (home ? " home-name" : "") }, displayName(it.e));
     g.appendChild(it.label);
     it.g = g;
-    it.hasLogo = Boolean(logo);
     svg.appendChild(g);
   }
   const halo = el("circle", { r: 10, fill: "none", stroke: "var(--keenable-blue)",
     "stroke-width": 1.5, "stroke-opacity": 0.6, visibility: "hidden" });
   svg.appendChild(halo);
   holder.appendChild(svg);
+  for (const it of items) {
+    const tw = it.label.getComputedTextLength();
+    it.right = it.px + 11 + tw <= M.left + iw - 6;
+    it.label.setAttribute("text-anchor", it.right ? "start" : "end");
+    it.x0 = it.right ? (it.logo ? it.px - 27 : it.px + 11) : it.px - 11 - tw;
+    it.x1 = it.right ? it.px + 11 + tw : (it.logo ? it.px + 27 : it.px - 11);
+  }
+  const yMin = M.top + 12, yMax = M.top + ih - 16;
+  for (let pass = 0; pass < 200; pass++) {
+    let moved = false;
+    for (let i = 0; i < items.length; i++) {
+      const a = items[i];
+      for (let j = 0; j < items.length; j++) {
+        if (i === j) continue;
+        const b = items[j];
+        if (j > i && a.x0 < b.x1 && b.x0 < a.x1) {
+          const d = 18 - Math.abs(a.labelY - b.labelY);
+          if (d > 0.5) {
+            const s = a.labelY <= b.labelY ? 1 : -1;
+            a.labelY -= s * d / 2;
+            b.labelY += s * d / 2;
+            moved = true;
+          }
+        }
+        if (b.px > a.x0 - 6 && b.px < a.x1 + 6 && Math.abs(b.px - a.px) > 5) {
+          const d = 15 - Math.abs(a.labelY - b.yPos);
+          if (d > 0.5) {
+            a.labelY += a.labelY >= b.yPos ? d : -d;
+            moved = true;
+          }
+        }
+      }
+      a.labelY = Math.max(yMin, Math.min(yMax, a.labelY));
+    }
+    if (!moved) break;
+  }
+  for (const it of items) {
+    if (Math.abs(it.labelY - it.yPos) > 5) {
+      it.g.insertBefore(el("line", { x1: it.px, y1: it.yPos + Math.sign(it.labelY - it.yPos) * 6,
+        x2: it.px, y2: it.labelY, stroke: "var(--baseline)", "stroke-width": 1 }), it.g.firstChild);
+    }
+    it.label.setAttribute("x", it.px + (it.right ? 11 : -11));
+    it.label.setAttribute("y", it.labelY + 4);
+    if (it.logo) {
+      it.logo.setAttribute("x", it.right ? it.px - 27 : it.px + 11);
+      it.logo.setAttribute("y", it.labelY - 8);
+    }
+  }
 
   const tip = el("div", { class: "tooltip qp-tip" });
   card.appendChild(tip);
@@ -2061,11 +2095,8 @@ function renderQualityPrice(rows) {
     for (const it of items) it.g.classList.remove("is-hot");
   }
   for (const it of items) {
-    const tw = it.label.getComputedTextLength();
-    const x0 = it.right ? (it.hasLogo ? it.px - 27 : it.px + 11) : it.px - 11 - tw;
-    const x1 = it.right ? it.px + 11 + tw : (it.hasLogo ? it.px + 27 : it.px - 11);
-    it.g.appendChild(el("rect", { class: "qp-hit", x: x0, y: it.labelY - 10,
-      width: Math.max(x1 - x0, 1), height: 20 }));
+    it.g.appendChild(el("rect", { class: "qp-hit", x: it.x0, y: it.labelY - 10,
+      width: Math.max(it.x1 - it.x0, 1), height: 20 }));
     it.g.appendChild(el("circle", { class: "qp-hit", cx: it.px, cy: it.yPos, r: 11 }));
     it.g.addEventListener("pointerenter", () => showTip(it));
     it.g.addEventListener("pointerleave", hideTip);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1955,7 +1955,7 @@ function renderQualityPrice(rows) {
   const yHi = Math.min(1, Math.ceil((Math.max(...qs) + 0.04) * 20) / 20);
   const yStep = yHi - yLo <= 0.3 ? 0.05 : 0.1;
   const xPad = 30;
-  const X = (v) => M.left + xPad + Math.sqrt(v / xTop) * (iw - xPad);
+  const X = (v) => M.left + xPad + (v / xTop) * (iw - xPad);
   const Y = (v) => M.top + (1 - (v - yLo) / (yHi - yLo)) * ih;
   const svg = el("svg", { viewBox: `0 0 ${W} ${H}`, width: W, height: H, role: "img",
     "aria-label": "Overall quality as share of ultimate vs price per 1,000 queries" });
@@ -2018,49 +2018,47 @@ function renderQualityPrice(rows) {
   holder.appendChild(svg);
   for (const it of items) {
     const tw = it.label.getComputedTextLength();
-    it.right = it.px + 11 + tw <= M.left + iw - 6;
+    it.off = it.logo ? 31 : 11;
+    it.right = it.px + it.off + tw <= M.left + iw - 6;
     it.label.setAttribute("text-anchor", it.right ? "start" : "end");
-    it.x0 = it.right ? (it.logo ? it.px - 27 : it.px + 11) : it.px - 11 - tw;
-    it.x1 = it.right ? it.px + 11 + tw : (it.logo ? it.px + 27 : it.px - 11);
+    it.x0 = it.right ? it.px + 11 : it.px - it.off - tw;
+    it.x1 = it.right ? it.px + it.off + tw : it.px - 11;
   }
   const yMin = M.top + 12, yMax = M.top + ih - 16;
-  for (let pass = 0; pass < 200; pass++) {
-    let moved = false;
-    for (let i = 0; i < items.length; i++) {
-      const a = items[i];
-      for (let j = 0; j < items.length; j++) {
-        if (i === j) continue;
-        const b = items[j];
-        if (j > i && a.x0 < b.x1 && b.x0 < a.x1) {
-          const d = 18 - Math.abs(a.labelY - b.labelY);
-          if (d > 0.5) {
-            const s = a.labelY <= b.labelY ? 1 : -1;
-            a.labelY -= s * d / 2;
-            b.labelY += s * d / 2;
-            moved = true;
-          }
-        }
-        if (b.px > a.x0 - 6 && b.px < a.x1 + 6 && Math.abs(b.px - a.px) > 5) {
-          const d = 15 - Math.abs(a.labelY - b.yPos);
-          if (d > 0.5) {
-            a.labelY += a.labelY >= b.yPos ? d : -d;
-            moved = true;
-          }
-        }
-      }
-      a.labelY = Math.max(yMin, Math.min(yMax, a.labelY));
+  const order = [...items].sort((a, b) => a.yPos - b.yPos || a.px - b.px);
+  const placed = [];
+  const clash = (it, y) => {
+    for (const o of placed) {
+      if (it.x0 < o.x1 && o.x0 < it.x1 && Math.abs(y - o.labelY) < 18) return true;
     }
-    if (!moved) break;
+    for (const o of items) {
+      if (o !== it && o.px > it.x0 - 6 && o.px < it.x1 + 6 &&
+          Math.abs(o.px - it.px) > 5 && Math.abs(y - o.yPos) < 14) return true;
+    }
+    return false;
+  };
+  for (const it of order) {
+    it.labelY = it.yPos;
+    for (let k = 0; k <= 24; k++) {
+      const cand = it.yPos + (k % 2 ? 1 : -1) * Math.ceil(k / 2) * 6;
+      if (cand < yMin || cand > yMax) continue;
+      if (!clash(it, cand)) {
+        it.labelY = cand;
+        break;
+      }
+    }
+    it.labelY = Math.max(yMin, Math.min(yMax, it.labelY));
+    placed.push(it);
   }
   for (const it of items) {
     if (Math.abs(it.labelY - it.yPos) > 5) {
       it.g.insertBefore(el("line", { x1: it.px, y1: it.yPos + Math.sign(it.labelY - it.yPos) * 6,
         x2: it.px, y2: it.labelY, stroke: "var(--baseline)", "stroke-width": 1 }), it.g.firstChild);
     }
-    it.label.setAttribute("x", it.px + (it.right ? 11 : -11));
+    it.label.setAttribute("x", it.px + (it.right ? it.off : -it.off));
     it.label.setAttribute("y", it.labelY + 4);
     if (it.logo) {
-      it.logo.setAttribute("x", it.right ? it.px - 27 : it.px + 11);
+      it.logo.setAttribute("x", it.right ? it.px + 11 : it.px - 27);
       it.logo.setAttribute("y", it.labelY - 8);
     }
   }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1954,7 +1954,8 @@ function renderQualityPrice(rows) {
   const yLo = Math.max(0, Math.floor((Math.min(...qs) - 0.04) * 20) / 20);
   const yHi = Math.min(1, Math.ceil((Math.max(...qs) + 0.04) * 20) / 20);
   const yStep = yHi - yLo <= 0.3 ? 0.05 : 0.1;
-  const X = (v) => M.left + (v / xTop) * iw;
+  const xPad = 30;
+  const X = (v) => M.left + xPad + (v / xTop) * (iw - xPad);
   const Y = (v) => M.top + (1 - (v - yLo) / (yHi - yLo)) * ih;
   const svg = el("svg", { viewBox: `0 0 ${W} ${H}`, width: W, height: H, role: "img",
     "aria-label": "Overall quality as share of ultimate vs price per 1,000 queries" });
@@ -1992,12 +1993,16 @@ function renderQualityPrice(rows) {
   xT.appendChild(el("tspan", { class: "dim" }, " — lowest public tier"));
   svg.appendChild(xT);
   const items = pts.map((p) => ({ ...p, px: X(p.usd), yPos: Y(p.q), right: X(p.usd) < M.left + iw - 130 }));
-  const clusters = new Map();
-  for (const it of items) {
-    const k = `${it.usd}|${it.right}`;
-    clusters.set(k, [...(clusters.get(k) || []), it]);
+  const clusters = [];
+  for (const side of [true, false]) {
+    const row = items.filter((it) => it.right === side).sort((a, b) => a.px - b.px);
+    let group = null;
+    for (const it of row) {
+      if (group && it.px - group[group.length - 1].px < 90) group.push(it);
+      else clusters.push(group = [it]);
+    }
   }
-  for (const group of clusters.values()) stackLabels(group, M.top + 12, M.top + ih - 10, 18);
+  for (const group of clusters) stackLabels(group, M.top + 12, M.top + ih - 10, 18);
   for (const it of items) {
     const g = el("g", { class: "qp-mark" });
     const home = it.e === HOME_ENGINE;


### PR DESCRIPTION
TinyFish's $0 price exposed how fragile the "Overall quality vs price" scatter was: the dot sat on the plot frame with its logo outside the chart, and the text labels could not fit seventeen engines clustered at the cheap end and the $5 flat tier.

Changes in `renderQualityPrice` (x-axis stays linear):

1. Inset the x-scale 30px so x=$0 renders inside the frame.
2. Markers are now the 18px engine logos themselves — no text labels, no leader lines. The hover tooltip still carries name, exact quality, price, and plan. The home engine gets a blue ring.
3. Coincident icons (e.g. the $5 flat-tier column) get the minimum vertical nudge — 5px steps, 17px clearance, downward first to preserve order — so every engine stays visible and hoverable.
4. X-ticks skip values that would land closer than 48px (matters on narrow viewports).

Before: https://paste.keenable.ai/needle-qp-tinyfish-before
After: https://paste.keenable.ai/needle-qp-tinyfish-after
After, narrow viewport: https://paste.keenable.ai/needle-qp-tinyfish-after-narrow

Verified against real gh-pages data served locally, screenshotted with headless chromium at 1280px and 420px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)