### PR TITLE
Fit the sharing matrices on mobile again

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -392,11 +392,16 @@
   }
   .bar-table .bar-fill { display: block; height: 100%; border-radius: 0; }
   @media (max-width: 560px) {
-    .overlap-matrix table { border-spacing: 1px; font-size: 10px; }
+    .overlap-matrix table { border-spacing: 1px; font-size: 9px; }
     .overlap-matrix td:first-child { padding: 0 3px 0 1px; }
     .overlap-matrix td:first-child .ename { display: none; }
     .overlap-matrix th:last-child, .overlap-matrix td.row-logo { display: none; }
-    .overlap-matrix td.overlap-cell { width: 21px; min-width: 21px; height: 24px; }
+    .overlap-matrix td.overlap-cell { width: auto; min-width: 14px; height: 22px; padding: 0 1px; }
+    .overlap-matrix td.overlap-cell .pct { display: none; }
+    .overlap-matrix th.col .key-logo,
+    .overlap-matrix th.col .key,
+    .overlap-matrix td:first-child .key-logo,
+    .overlap-matrix td:first-child .key { width: 13px; height: 13px; }
     .bar-table { font-size: 12px; }
     .bar-table td, .bar-table th { padding: 6px 4px; }
     .bar-table td:last-child, .bar-table th:last-child { white-space: normal; }
@@ -2235,8 +2240,9 @@ function overlapMatrix(holder, engines, cellFor, pairNote = "of queries share su
     const rowCells = [];
     for (const [j, b] of engines.entries()) {
       const cell = a === b ? null : cellFor(a, b);
-      const td = el("td", { class: "overlap-cell" }, cell ? cell.text : "–");
+      const td = el("td", { class: "overlap-cell" }, cell ? cell.text.replace(/%$/, "") : "–");
       if (cell) {
+        if (cell.text.endsWith("%")) td.appendChild(el("span", { class: "pct" }, "%"));
         td.style.background = OVERLAP_BG[cell.step];
         td.style.color = OVERLAP_INK[cell.step];
         td.title = cell.title;


### PR DESCRIPTION
The 560px rules from 5f40208 sized matrix cells at a fixed 21px for the 11x11 grid of that time. The grid is now 15x15, so on phones the suspicious-sharing and URL-intersection matrices clipped at the card edge and hid the last columns.

Fixed widths break each time an engine lands, so below 560px cells are now content-sized instead:

- the `%` suffix renders in a `.pct` span that mobile hides (the subtitle and the pair line still name the unit; desktop shows `%` as before)
- font drops to 9px, logos shrink to 13px, `min-width: 14px` keeps single-digit cells square
- `overflow-x: auto` stays as the fallback if the grid outgrows this too

Verified with headless Chromium against live gh-pages data at 360, 390, and 1100px: the full 15x15 grid fits at 360px, `docScrollWidth == innerWidth`, no element crosses the viewport, desktop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)