### PR TITLE
Unhide Octen on the dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -58,6 +58,7 @@
     --series-13: #B3322B;
     --series-14: #8A7500;
     --series-15: #0F6E8C;
+    --series-16: #C2185B;
   }
   * { box-sizing: border-box; }
   body {
@@ -958,7 +959,7 @@ const RUNS_BASE = "https://huggingface.co/datasets/keenable-ai/needle-results/re
 
 let ENGINES = [];
 const ENGINE_SLOT = new Map();
-const HIDDEN_ENGINES = new Set(["ceramic", "octen", "keenable"]);
+const HIDDEN_ENGINES = new Set(["ceramic", "keenable"]);
 
 function registerEngines(names) {
   for (const name of names) {
@@ -971,9 +972,9 @@ function registerEngines(names) {
 
 registerEngines(["keenable-realtime", "google", "bing", "brave", "brave-llmcontext",
   "exa", "exa-instant", "parallel", "parallel-turbo", "perplexity", "tavily", "you", "firecrawl",
-  "tinyfish", "kagi"]);
+  "tinyfish", "kagi", "octen"]);
 
-const SERIES_COUNT = 15;
+const SERIES_COUNT = 16;
 function colorOf(engine) {
   if (engine === ULTIMATE_ENGINE) return "var(--text-muted)";
   const slot = ENGINE_SLOT.get(engine);


### PR DESCRIPTION
Octen has run in every bench since 2026-07-11 and its rows are already in `history.jsonl`, `overlap.jsonl`, and `uniqueness.jsonl`, but `HIDDEN_ENGINES` kept it out of every view.

Changes in `dashboard/index.html`:
- drop `"octen"` from `HIDDEN_ENGINES`
- register it as the sixteenth engine and bump `SERIES_COUNT` to 16
- add `--series-16` so it gets a real color instead of the muted overflow fallback

Verified locally against the current gh-pages data: Octen renders in standings, slice trends, the latency dumbbell, and the suspicious-sharing matrix with no console errors.

Context from the published data: Octen's suspicious-sharing rates sit at or below the median pair (max 8.8% vs you.com, vs 89.5% for brave/you). Its 383 scholar search errors all come from three runs on 2026-07-11 and are HTTP 429 rate limits, not query-shape failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
